### PR TITLE
fix(ng-add): handling src/assets/svg empty folder

### DIFF
--- a/schematics/src/ng-add/index.ts
+++ b/schematics/src/ng-add/index.ts
@@ -120,8 +120,17 @@ function addScripts({ project }): Rule {
 }
 
 process.on('exit', function() {
+  const dirPath = './src/assets/svg';
+  if(!fs.existsSync(dirPath)){
+    fs.mkdirSync(dirPath);
+  }
+  const dir = fs.readdirSync(dirPath);
+  if(dir.length < 1){
+    console.log(`✅️ Ready. Put your svg icons in src/assets/svg and then 'npm run generate-icons'`);
+  }
   require('child_process').execSync('npm run generate-icons');
   console.log(`✅️ npm run generate-icons`);
+  return;
 });
 
 export default function ngAdd(options: Schema): Rule {


### PR DESCRIPTION
closes #20 