### PR TITLE
docs: removed non-existent outputDirectory option from svgGenerator c…

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ For example, if the `fill` or `stroke` properties of elements in the svg are set
     "outputPath": "./src/app/svg",
     "prefix": "app",
     "srcPath": "./src/assets/svg",
-    "outputDirectory": "./src/app",
     "svgoConfig": {
       "plugins": [
         {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

Removed non-existent `outputDirectory` option from svgGenerator config in the README

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Option `outputDirectory` exists in the documentation, but there is no any bindings in the source code to it

## What is the new behavior?

Option `outputDirectory` removed from README

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
