### PR TITLE
feat: 🎸 add ability to export all icons in root and folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,30 @@ import { unknownIcon } from '@app/svg/unknown';
 export class AppModule {}
 ```
 
+## Export all icons
+
+If you want to export all icons from a single file you can add **exportable** to svg-generator configuration:
+
+```json
+{
+  "svgGenerator": {
+    ...
+    "exportable": true
+  }
+}
+```
+
+Inside `./src/app/svg` folder will be generated **index.ts** file with all exported icons.
+
+```ts
+export { homeIcon } from './group/home';
+export { userIcon } from './group/user';
+export { dashboardTwoIcon } from './group-two/dashboard-two';
+export { locationTwoIcon } from './group-two/location-two';
+```
+
+Make sure all of the icons have different names.
+
 ## Contributors ✨
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):

--- a/src/app/svg/index.ts
+++ b/src/app/svg/index.ts
@@ -1,0 +1,4 @@
+export { homeIcon } from './group/home';
+export { userIcon } from './group/user';
+export { dashboardTwoIcon } from './group-two/dashboard-two';
+export { locationTwoIcon } from './group-two/location-two';

--- a/svg-generator/ast.ts
+++ b/svg-generator/ast.ts
@@ -1,10 +1,11 @@
-import { createModifier, factory, NodeFlags, SyntaxKind } from 'typescript';
-import kebabCase from 'lodash.kebabcase';
 import camelcase from 'camelcase';
+import kebabCase from 'lodash.kebabcase';
+import { createModifier, factory, NodeFlags, SyntaxKind } from 'typescript';
 
 interface Base {
   identifierName: string;
   iconName: string;
+  dirName?: string;
 }
 
 export function createStatement({ identifierName, svgContent, iconName }: Base & { svgContent: string }) {
@@ -36,7 +37,7 @@ export function createStatement({ identifierName, svgContent, iconName }: Base &
   );
 }
 
-export function createExportDeclaration({ identifierName, iconName }: Base) {
+export function createExportDeclaration({ identifierName, iconName, dirName = '' }: Base) {
   return factory.createExportDeclaration(
     undefined,
     undefined,
@@ -45,7 +46,7 @@ export function createExportDeclaration({ identifierName, iconName }: Base) {
       undefined,
       factory.createIdentifier(identifierName)
     )]),
-    factory.createStringLiteral(`./${iconName}`, true)
+    factory.createStringLiteral(`.${dirName}/${iconName}`, true)
   );
 }
 

--- a/svg-generator/types.ts
+++ b/svg-generator/types.ts
@@ -2,6 +2,7 @@ export interface Config {
   srcPath: string;
   outputPath: string;
   svgoConfig: object;
+  exportable?: boolean;
   prefix?: string;
   postfix?: string;
 }


### PR DESCRIPTION
all icons can be exported from index.ts file in root, or from
group/index.ts file.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

I had a case where I needed to export all icons from one file. Ex: In content management system, I want to give user ability to choose any icon.

I have another case where I have entry points in my project and to make icons work, I have to export every icon from **public-api.ts** file.

Issue Number: N/A

## What is the new behavior?

With this change, no index.ts file will be generated in root directory, with every icons exported. Also export statement will be added to group folders index.ts file.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
