### PR TITLE
fix: 🐛 icons multi provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ Now we can use the `svg-icon` component:
 <svg-icon key="settings"></svg-icon> <svg-icon key="settings" color="hotpink" fontSize="40px"></svg-icon>
 ```
 
-## Lazy Loaded Modules
+## Register icons locally
 
-In lazy load modules, we can use the `forChild` method:
+In lazy load modules or in reusable component modules, we can use the `forChild` method, for register icons accessible locally in these modules:
 
 ```ts
 import { dashboardIcon } from '@app/svg/dashboard';

--- a/projects/ngneat/svg-icon/src/lib/svg-icons.module.ts
+++ b/projects/ngneat/svg-icon/src/lib/svg-icons.module.ts
@@ -24,17 +24,17 @@ export class SvgIconsModule {
   static forChild(icons: SvgIconType | SvgIconType[]): ModuleWithProviders<SvgIconsModule> {
     return {
       ngModule: SvgIconsModule,
-      providers: [{ provide: SVG_ICONS, useValue: icons }],
+      providers: [{ provide: SVG_ICONS, useValue: icons, multi: true }],
     };
   }
 
   constructor(
-    @Optional() @Inject(SVG_ICONS) icons: SvgIconType | SvgIconType[],
+    @Optional() @Inject(SVG_ICONS) icons: SvgIconType[] | SvgIconType[][],
     @Optional() @Inject(SVG_MISSING_ICON_FALLBACK) missingIconFallback: SvgIconType,
     private service: SvgIconRegistry
   ) {
     if (icons) {
-      this.service.register(icons);
+      this.service.register(([] as SvgIconType[]).concat(...icons));
     }
 
     if (missingIconFallback) {

--- a/projects/ngneat/svg-icon/src/lib/svg-icons.module.ts
+++ b/projects/ngneat/svg-icon/src/lib/svg-icons.module.ts
@@ -1,4 +1,4 @@
-import { Inject, ModuleWithProviders, NgModule, Optional } from '@angular/core';
+import { Inject, ModuleWithProviders, NgModule, Optional, Self } from '@angular/core';
 
 import { SvgIconRegistry } from './registry';
 import { SvgIconComponent } from './svg-icon.component';
@@ -29,7 +29,7 @@ export class SvgIconsModule {
   }
 
   constructor(
-    @Optional() @Inject(SVG_ICONS) icons: SvgIconType[] | SvgIconType[][],
+    @Optional() @Self() @Inject(SVG_ICONS) icons: SvgIconType[] | SvgIconType[][],
     @Optional() @Inject(SVG_MISSING_ICON_FALLBACK) missingIconFallback: SvgIconType,
     private service: SvgIconRegistry
   ) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

If has two modules (A and B) that use `SvgIconsModule.forChild()` and this modules imports to module C then will be provided only icons from last imported module (for example B) and icons from other modules ( for example A) will be ignored.  

Issue Number: N/A

## What is the new behavior?

Now icons provider with `multi: true` parameter. It's mean that all provided icons will accessible as array by same token.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
