### PR TITLE
feat: pass file path to SVG Optimizer

### DIFF
--- a/svg-generator/tree.ts
+++ b/svg-generator/tree.ts
@@ -54,10 +54,11 @@ export function createTree(srcPath: string, outputPath: string, config: Omit<Con
         const iconName = basename(file.name, '.svg');
         const path = join(outputPath, file.name).replace('.svg', '.ts');
         const identifierName = camelcase(`${config.prefix}-${iconName}-${config.postfix}`);
-        const svgContent = readFileSync(join(srcPath, file.name)).toString();
+        const svgPath = join(srcPath, file.name);
+        const svgContent = readFileSync(svgPath).toString();
 
         const statement = createStatement({
-          svgContent: optimize(svgContent, { plugins }).data,
+          svgContent: optimize(svgContent, { plugins, path: svgPath }).data,
           iconName,
           identifierName,
         });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The SVG generator doesn't pass the path parameter when calling SVG Optimize. This leads to some features not working with SVG Optimize plugins. The concrete example I found is when you use `prefixIds` plugin it would use the source file's name as a prefix by default. The exact implementation can be seen here: https://github.com/svg/svgo/blob/master/plugins/prefixIds.js#L194

Issue Number: N/A

## What is the new behavior?

SVG generator passes path parameter to SVG Optimize.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
