### PR TITLE
Fix schema ID for Angular 13

### DIFF
--- a/schematics/src/ng-add/schema.json
+++ b/schematics/src/ng-add/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/schema",
-  "id": "SchematicsSvgIconAdd",
+  "$id": "SchematicsSvgIconAdd",
   "title": "Add svg-icon to Your Project",
   "type": "object",
   "properties": {


### PR DESCRIPTION
Trying to ng add this into Angular 13.0.2 I am getting the following error:

```
An unhandled exception occurred: NOT SUPPORTED: keyword "id", use "$id" for schema ID
```

Hopefully this PR would be enough as I am not sure if that is all what it needs.
