### PR TITLE
feature(svg-generator): Add config-dir option to svg-generator CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ For example, if the `fill` or `stroke` properties of elements in the svg are set
 
 - Run `npm run generate-icons`
 
+## Custom config
+
+The `svgGenerator` config object is placed by default in your main `package.json`.
+
+It can also be placed in any location supported by the [Cosmiconfig library](https://github.com/davidtheclark/cosmiconfig) such as a custom `.svgGeneratorrc.json` file.
+
+The config object is looked for in the project root directory by default.
+
+If your config object is located in another directory, you can specify it through the `--config-dir` option of the `svg-generator` CLI: `npm run svg-generator --config-dir=/your/custom/dir/where/the/config/is/located`. The config object will then be looked for in all valid [Cosmiconfig library](https://github.com/davidtheclark/cosmiconfig) locations starting from that directory and going up the directory tree until a config is found.
+
 ## Icons Rendering
 
 Import the `SvgIconsModule` in your `AppModule`, and register the icons:
@@ -80,7 +90,7 @@ export class AppModule {}
 Now we can use the `svg-icon` component:
 
 ```html
-<svg-icon key="settings"></svg-icon> 
+<svg-icon key="settings"></svg-icon>
 <svg-icon key="settings" color="hotpink" fontSize="40px"></svg-icon>
 ```
 

--- a/svg-generator/index.ts
+++ b/svg-generator/index.ts
@@ -1,9 +1,24 @@
 #!/usr/bin/env node
-import { generateSVGIcons } from './generator';
+import { Command } from 'commander';
 import { cosmiconfigSync } from 'cosmiconfig';
+import { generateSVGIcons } from './generator';
 import { Config } from './types';
 
+const program = new Command();
+program
+  .name('svg-generator')
+  .description('Transform SVG files into Angular-compatible TS files')
+  .version('4.0.0')
+  .option(
+    '-c, --config-dir <value>',
+    'Specify a directory for the config file (defaults to current working directory)',
+    process.cwd()
+  );
+
+program.parse();
+const opts = program.opts();
+
 const explorerSync = cosmiconfigSync('svgGenerator');
-const config: Config | null = explorerSync.search()?.config;
+const config: Config | null = explorerSync.search(opts.configDir)?.config;
 
 generateSVGIcons(config);

--- a/svg-generator/package-lock.json
+++ b/svg-generator/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "camelcase": "6.2.0",
         "chokidar": "3.5.1",
+        "commander": "9.2.0",
         "cosmiconfig": "7.0.0",
         "fs-extra": "10.0.0",
         "glob": "7.1.7",
@@ -1939,11 +1940,11 @@
       }
     },
     "node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.2.0.tgz",
+      "integrity": "sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==",
       "engines": {
-        "node": ">= 10"
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/concat-map": {
@@ -5539,6 +5540,14 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/svgo/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -7505,9 +7514,9 @@
       }
     },
     "commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.2.0.tgz",
+      "integrity": "sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -10205,6 +10214,13 @@
         "csso": "^4.2.0",
         "picocolors": "^1.0.0",
         "stable": "^0.1.8"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
+        }
       }
     },
     "symbol-tree": {

--- a/svg-generator/package.json
+++ b/svg-generator/package.json
@@ -29,7 +29,8 @@
     "glob": "7.1.7",
     "lodash.kebabcase": "4.1.1",
     "svgo": "2.8.0",
-    "typescript": "4.5.5"
+    "typescript": "4.5.5",
+    "commander": "9.2.0"
   },
   "devDependencies": {
     "@types/fs-extra": "9.0.11",


### PR DESCRIPTION
svg-generator CLI now takes an optional argument to specify where the svgGenerator
config object should be looked for, defaulting to previous behavior of looking
in the current working directory.

This allows to support use cases where separate instances of svg-generator shoud be
used in subdirectories of the target project (typically in a Nx monorepo setting).

Close #64

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #64 

## What is the new behavior?

A custom config dir can be specified for svg-generator CLI.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

Behaviour is unchanged when the new option is not used (defaults to current working directory, current behaviour).

Didn't see how to introduce an auto test for that, but it relies on the well-known `commander` package.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
