### PR TITLE
fix: allow referring to SVG_ICONS_CONFIG before being defined

### DIFF
--- a/projects/ngneat/svg-icon/src/lib/registry.ts
+++ b/projects/ngneat/svg-icon/src/lib/registry.ts
@@ -1,5 +1,5 @@
 import { DOCUMENT } from '@angular/common';
-import { inject, Inject, Injectable, Injector } from '@angular/core';
+import { forwardRef, inject, Inject, Injectable } from '@angular/core';
 
 import { SVG_CONFIG, SVG_ICONS_CONFIG, SvgIconType } from './providers';
 
@@ -14,7 +14,7 @@ export class SvgIconRegistry {
   private svgMap = new Map<string, SvgIcon>();
   private document = inject(DOCUMENT);
 
-  constructor(@Inject(SVG_ICONS_CONFIG) config: SVG_CONFIG) {
+  constructor(@Inject(forwardRef(() => SVG_ICONS_CONFIG)) config: SVG_CONFIG) {
     if (config?.icons) {
       this.register(config.icons);
     }


### PR DESCRIPTION
Close #114

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #114 

## What is the new behavior?

SVG_ICONS_CONFIG injection doesn't fail while it's still not defined and Jest is able to run successfully.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
